### PR TITLE
Fixed MMR Volatility max games

### DIFF
--- a/src/utils/algorithms/calculateMMR.ts
+++ b/src/utils/algorithms/calculateMMR.ts
@@ -177,7 +177,7 @@ export async function calculateNewMMR(
           : currentVolatility
 
         const newMMR = parseFloat((oldMMR + mmrChange).toFixed(1))
-        const newVolatility = Math.min(oldVolatility + 1, 10)
+        const newVolatility = Math.min(oldVolatility + 1, 15)
 
         player.elo = clamp(newMMR, 0, 9999)
         player.elo_change = parseFloat(mmrChange.toFixed(1))


### PR DESCRIPTION
we changed mmr volatility to 1.75 from 1.5 but kept old max of 10 games