### PR TITLE
Ban rejoin enforcement + persistent strikes/bans with harsher scaling

### DIFF
--- a/migrations/1780000000000_bans-keep-expired.mjs
+++ b/migrations/1780000000000_bans-keep-expired.mjs
@@ -1,0 +1,27 @@
+/**
+ * @type {import('node-pg-migrate').ColumnDefinitions | undefined}
+ */
+export const shorthands = undefined;
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+export const up = (pgm) => {
+    // Expired bans are no longer deleted; keep them as a permanent record.
+    // This flag marks that the one-time unban side effects (role removal, DM,
+    // log) have already run, so checkBans does not re-process expired rows.
+    pgm.addColumn('bans', {
+        expiry_handled: { type: 'boolean', notNull: true, default: false }
+    });
+};
+
+/**
+ * @param pgm {import('node-pg-migrate').MigrationBuilder}
+ * @param run {() => void | undefined}
+ * @returns {Promise<void> | void}
+ */
+export const down = (pgm) => {
+    pgm.dropColumn('bans', 'expiry_handled');
+};

--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -112,6 +112,7 @@ declare module 'psqlDB' {
     expires_at?: Date | null
     related_strike_ids?: number[] | null
     allowed_queue_ids?: number[] | null
+    expiry_handled?: boolean
   }
 
   export interface Strikes {

--- a/src/api/routers/commands/moderation.router.ts
+++ b/src/api/routers/commands/moderation.router.ts
@@ -459,7 +459,8 @@ async function buildPlayersPage({
       display_name: userId,
       avatar_url: null,
     }
-    const userStrikes = (strikesByUser.get(userId) ?? []).map((strike) =>
+    const rawUserStrikes = strikesByUser.get(userId) ?? []
+    const userStrikes = rawUserStrikes.map((strike) =>
       serializeStrike(strike, users),
     )
     const activeBan = serializeBan(activeBanMap.get(userId) ?? null)
@@ -472,8 +473,13 @@ async function buildPlayersPage({
       ...user,
       strikes: userStrikes,
       active_ban: activeBan,
-      total_strike_points: userStrikes.reduce(
-        (runningTotal, strike) => runningTotal + strike.amount,
+      // Only non-expired strikes count toward the total; expired strikes are
+      // retained in the list above as history.
+      total_strike_points: rawUserStrikes.reduce(
+        (runningTotal, strike) =>
+          strike.expires_at && new Date(strike.expires_at).getTime() < Date.now()
+            ? runningTotal
+            : runningTotal + strike.amount,
         0,
       ),
       latest_strike_at: latestStrikeAt,
@@ -538,6 +544,7 @@ async function listModerationPlayersFast({
         WITH strike_users AS (
           SELECT user_id, MAX(issued_at) AS latest_strike_at
           FROM strikes
+          WHERE expires_at > NOW()
           GROUP BY user_id
         ),
         ban_only_users AS (
@@ -567,6 +574,7 @@ async function listModerationPlayersFast({
         WITH strike_users AS (
           SELECT user_id
           FROM strikes
+          WHERE expires_at > NOW()
           GROUP BY user_id
         ),
         ban_only_users AS (
@@ -608,6 +616,7 @@ async function listModerationPlayersFast({
     `
       SELECT user_id, MAX(issued_at) AS latest_strike_at
       FROM strikes
+      WHERE expires_at > NOW()
       GROUP BY user_id
       ORDER BY MAX(issued_at) DESC, user_id ASC
       LIMIT $1 OFFSET $2
@@ -618,6 +627,7 @@ async function listModerationPlayersFast({
     `
       SELECT COUNT(DISTINCT user_id)::int AS total
       FROM strikes
+      WHERE expires_at > NOW()
     `,
   )
   const strikeLatestMap = new Map(
@@ -684,6 +694,7 @@ async function listModerationPlayers({
           `SELECT user_id, MAX(issued_at) AS latest_strike_at
            FROM strikes
            WHERE user_id = ANY($1::text[])
+             AND expires_at > NOW()
            GROUP BY user_id`,
           [[...searchUserIds]],
         )
@@ -692,6 +703,7 @@ async function listModerationPlayers({
         : pool.query<{ user_id: string; latest_strike_at: Date | null }>(
             `SELECT user_id, MAX(issued_at) AS latest_strike_at
              FROM strikes
+             WHERE expires_at > NOW()
              GROUP BY user_id`,
           ),
   ])
@@ -1628,7 +1640,7 @@ moderationRouter.openapi(
       if (filter === 'banned') {
         filterJoin = `INNER JOIN bans b ON b.user_id = gm.user_id AND (b.expires_at IS NULL OR b.expires_at > NOW())`
       } else if (filter === 'striked') {
-        filterJoin = `INNER JOIN (SELECT DISTINCT user_id FROM strikes) s ON s.user_id = gm.user_id`
+        filterJoin = `INNER JOIN (SELECT DISTINCT user_id FROM strikes WHERE expires_at > NOW()) s ON s.user_id = gm.user_id`
       }
 
       const sortJoin =
@@ -1636,6 +1648,7 @@ moderationRouter.openapi(
           ? `LEFT JOIN (
                SELECT user_id, MAX(issued_at) AS latest_strike_at
                FROM strikes
+               WHERE expires_at > NOW()
                GROUP BY user_id
              ) ls ON ls.user_id = gm.user_id`
           : ''

--- a/src/command-handlers/moderation/createBan.ts
+++ b/src/command-handlers/moderation/createBan.ts
@@ -56,7 +56,8 @@ export async function createBan({
       SET reason = EXCLUDED.reason,
           allowed_queue_ids = EXCLUDED.allowed_queue_ids,
           expires_at = EXCLUDED.expires_at,
-          related_strike_ids = EXCLUDED.related_strike_ids
+          related_strike_ids = EXCLUDED.related_strike_ids,
+          expiry_handled = false
       WHERE bans.expires_at IS NOT NULL
         AND bans.expires_at <= NOW()
       RETURNING *

--- a/src/command-handlers/moderation/createStrike.ts
+++ b/src/command-handlers/moderation/createStrike.ts
@@ -47,6 +47,7 @@ export async function createStrike({
           SELECT id
           FROM strikes
           WHERE user_id = $1
+            AND expires_at > NOW()
           LIMIT 1
         `,
         [userId],
@@ -55,7 +56,7 @@ export async function createStrike({
 
   const finalAmount = hasPriorStrikes && amount === 0 ? 1 : amount
   const expiresAt =
-    (await calculateExpiryDate(userId)) ??
+    (await calculateExpiryDate(userId, finalAmount)) ??
     new Date(Date.now() + DEFAULT_STRIKE_EXPIRY_MS)
   const issuedAt = new Date()
 
@@ -82,6 +83,7 @@ export async function createStrike({
       SELECT COALESCE(SUM(amount), 0)::int AS total
       FROM strikes
       WHERE user_id = $1
+        AND expires_at > NOW()
     `,
     [userId],
   )

--- a/src/commands/moderation/playerModeration/listBannedUsers.ts
+++ b/src/commands/moderation/playerModeration/listBannedUsers.ts
@@ -4,6 +4,7 @@ import { Bans } from 'psqlDB'
 import {
   createModerationListEmbed,
   formatBanLogEntry,
+  isExpired,
 } from './moderationLogUtils'
 import { resolveModerationTarget } from '../../../command-handlers/moderation/resolveModerationTarget'
 
@@ -15,7 +16,13 @@ export default {
       const bannedUsers: Bans[] = (await pool.query(`SELECT * FROM "bans"`))
         .rows
 
+      // Active bans first, then expired. Within active, soonest-to-expire
+      // first (permanent bans, null expiry, sort last via +Infinity).
       const sortedBans = [...bannedUsers].sort((a, b) => {
+        const aExpired = isExpired(a.expires_at)
+        const bExpired = isExpired(b.expires_at)
+        if (aExpired !== bExpired) return aExpired ? 1 : -1
+
         const aTime = a.expires_at
           ? new Date(a.expires_at).getTime()
           : Number.POSITIVE_INFINITY
@@ -25,6 +32,10 @@ export default {
 
         return aTime - bTime
       })
+      const activeBanCount = sortedBans.filter(
+        (ban) => !isExpired(ban.expires_at),
+      ).length
+      const expiredBanCount = sortedBans.length - activeBanCount
       const targetEntries = await Promise.all(
         sortedBans.map(
           async (ban): Promise<readonly [string, string]> => [
@@ -37,8 +48,8 @@ export default {
 
       const embed = createModerationListEmbed({
         title: 'Ban Log',
-        summary: `Active bans: ${sortedBans.length}`,
-        emptyState: 'No active bans.',
+        summary: `Active bans: ${activeBanCount}${expiredBanCount > 0 ? ` · Expired: ${expiredBanCount}` : ''}`,
+        emptyState: 'No bans on record.',
         entries: sortedBans.map((ban) =>
           formatBanLogEntry(
             ban,

--- a/src/commands/moderation/playerModeration/listStrikes.ts
+++ b/src/commands/moderation/playerModeration/listStrikes.ts
@@ -4,6 +4,7 @@ import { getGuild } from '../../../client'
 import {
   createModerationListEmbed,
   formatStrikeLogEntry,
+  isExpired,
 } from './moderationLogUtils'
 
 export default {
@@ -15,10 +16,13 @@ export default {
       const guild = await getGuild()
       const member =
         guild.members.cache.get(user.id) ?? (await guild.members.fetch(user.id))
-      const sortedStrikes = [...strikeInfo].sort(
-        (a, b) =>
-          new Date(b.issued_at).getTime() - new Date(a.issued_at).getTime(),
-      )
+      // Active strikes first, then expired; each group newest-first.
+      const sortedStrikes = [...strikeInfo].sort((a, b) => {
+        const aExpired = isExpired(a.expires_at)
+        const bExpired = isExpired(b.expires_at)
+        if (aExpired !== bExpired) return aExpired ? 1 : -1
+        return new Date(b.issued_at).getTime() - new Date(a.issued_at).getTime()
+      })
       const issuedByIds = [
         ...new Set(sortedStrikes.map((strike) => strike.issued_by_id)),
       ]
@@ -35,14 +39,18 @@ export default {
         }),
       )
       const issuedByLookup = new Map(issuedByEntries)
-      const totalStrikes = sortedStrikes.reduce(
-        (total, strike) => total + strike.amount,
+      const activeStrikes = sortedStrikes.reduce(
+        (total, strike) =>
+          isExpired(strike.expires_at) ? total : total + strike.amount,
         0,
       )
+      const expiredCount = sortedStrikes.filter((strike) =>
+        isExpired(strike.expires_at),
+      ).length
 
       const embed = createModerationListEmbed({
         title: `${member.displayName} Strike Log`,
-        summary: `Entries: ${sortedStrikes.length} · Total strikes: ${totalStrikes}`,
+        summary: `Active strikes: ${activeStrikes} · Entries: ${sortedStrikes.length}${expiredCount > 0 ? ` (${expiredCount} expired)` : ''}`,
         emptyState: 'No strikes found for this user.',
         entries: sortedStrikes.map((strike) =>
           formatStrikeLogEntry(

--- a/src/commands/moderation/playerModeration/moderationLogUtils.ts
+++ b/src/commands/moderation/playerModeration/moderationLogUtils.ts
@@ -28,6 +28,12 @@ function formatDatePair(date: Date | null | undefined) {
   return `${formatDiscordDate(date)} (${formatDiscordDate(date, 'R')})`
 }
 
+// A null expiry means permanent (e.g. a permanent ban), which never expires.
+export function isExpired(expiresAt: Date | null | undefined): boolean {
+  if (!expiresAt) return false
+  return new Date(expiresAt).getTime() < Date.now()
+}
+
 function chunkEntries(entries: string[]) {
   const chunks: { start: number; end: number; value: string }[] = []
   let currentValue = ''
@@ -103,10 +109,13 @@ export function formatBanLogEntry(ban: Bans, targetLabel: string) {
       ? ban.related_strike_ids.map((id) => `#${id}`).join(', ')
       : 'Manual'
 
+  const expired = isExpired(ban.expires_at)
+  const statusTag = expired ? '🟥 [EXPIRED]' : '🟩 [ACTIVE]'
+
   return [
-    targetLabel,
+    `${statusTag} ${targetLabel}`,
     `Reason: ${normalizeText(ban.reason, 220)}`,
-    `Expires: ${formatDatePair(ban.expires_at)}`,
+    `${expired ? 'Expired' : 'Expires'}: ${formatDatePair(ban.expires_at)}`,
     `Source: ${relatedStrikes}`,
   ].join('\n')
 }
@@ -115,13 +124,16 @@ export function formatStrikeLogEntry(strike: Strikes, issuedBy: string) {
   const strikeAmountLabel =
     strike.amount === 1 ? '1 strike' : `${strike.amount} strikes`
 
+  const expired = isExpired(strike.expires_at)
+  const statusTag = expired ? '🟥 [EXPIRED]' : '🟩 [ACTIVE]'
+
   return [
-    `#${strike.id} · ${strikeAmountLabel}`,
+    `${statusTag} #${strike.id} · ${strikeAmountLabel}`,
     `Reason: ${normalizeText(strike.reason, 220)}`,
     `Issued by: ${issuedBy}`,
     `Reference: ${normalizeText(strike.reference, 100)}`,
     `Issued: ${formatDatePair(strike.issued_at)}`,
-    `Expires: ${formatDatePair(strike.expires_at)}`,
+    `${expired ? 'Expired' : 'Expires'}: ${formatDatePair(strike.expires_at)}`,
   ].join('\n')
 }
 

--- a/src/commands/superCommands/ban.ts
+++ b/src/commands/superCommands/ban.ts
@@ -126,7 +126,10 @@ export default {
     }
 
     const currentValue = String(focused.value ?? '').toLowerCase()
-    const bannedUsers = await getBannedUsers()
+    // Expired bans are kept as a record; only offer currently-banned users.
+    const bannedUsers = (await getBannedUsers()).filter(
+      (ban) => !ban.expires_at || new Date(ban.expires_at).getTime() > Date.now(),
+    )
 
     const users = (
       await Promise.all(

--- a/src/events/guildMemberAdd.ts
+++ b/src/events/guildMemberAdd.ts
@@ -1,10 +1,40 @@
 import { Events, type GuildMember } from 'discord.js'
 import { upsertGuildMember } from '../utils/guildMemberSync'
+import { pool } from '../db'
+
+// Blacklist roles used for ban visibility + tournament blacklisting.
+// Kept in sync with createBan / removeBan / automaticUnbans.
+const BLACKLIST_ROLE_IDS = ['1354296037094854788', '1344793211146600530']
 
 export default {
   name: Events.GuildMemberAdd,
   once: false,
   async execute(member: GuildMember) {
     await upsertGuildMember(member)
+
+    // Re-apply blacklist roles if the user still has an active ban in the DB.
+    // Discord strips all roles when a member leaves, so without this a banned
+    // user could leave and rejoin to shed the blacklist roles (and escape
+    // tournament blacklisting) even though the DB ban persists.
+    const activeBan = await pool.query(
+      `SELECT 1 FROM bans
+       WHERE user_id = $1
+         AND (expires_at IS NULL OR expires_at > NOW())
+       LIMIT 1`,
+      [member.id],
+    )
+
+    if (activeBan.rowCount && activeBan.rowCount > 0) {
+      await Promise.all(
+        BLACKLIST_ROLE_IDS.map((roleId) =>
+          member.roles.add(roleId).catch((err) => {
+            console.error(
+              `[BAN REAPPLY] Failed to re-add role ${roleId} to ${member.id}:`,
+              err,
+            )
+          }),
+        ),
+      )
+    }
   },
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 /// <reference path="./@types/discord.d.ts" />
 import './register-paths'
 import {
-  deleteExpiredStrikesCronJob,
   replenishReservePoolCronJob,
   runDecayTick,
   updateMatchCountCronJob,
@@ -76,9 +75,6 @@ if (env.NODE_ENV !== 'development') {
 //void deleteOldTranscriptsCronJob()
 void updateMatchCountCronJob().catch((error) =>
   console.error('[MATCH COUNT CRON ERROR]', error),
-)
-void deleteExpiredStrikesCronJob().catch((error) =>
-  console.error('[STRIKES CRON ERROR]', error),
 )
 
 // Start API server

--- a/src/utils/automaticUnbans.ts
+++ b/src/utils/automaticUnbans.ts
@@ -8,9 +8,12 @@ import { createEmbedType, logStrike } from './logCommandUse'
 import { getGuild } from '../client'
 
 export async function automaticUnban(ban: Bans) {
-  // remove ban
+  // Keep the ban row as a permanent record, but mark its expiry as handled so
+  // the one-time side effects below (role removal, DM, log) only run once.
   const userId = ban.user_id.toString()
-  await pool.query(`DELETE FROM "bans" WHERE user_id = $1`, [userId])
+  await pool.query(`UPDATE "bans" SET expiry_handled = true WHERE id = $1`, [
+    ban.id,
+  ])
   await sendDm(userId, moderationMessages.banLiftedDm({ expired: true }))
 
   const guild = await getGuild()
@@ -59,19 +62,17 @@ export async function automaticUnban(ban: Bans) {
 
 // check all bans for timeout. todo: replace with an api call from external service that is running a cronjob
 export async function checkBans() {
-  const res = await pool.query('SELECT * FROM "bans"')
-
-  const bans = res.rows
-  const currentTime = Date.now()
-
-  // filter for bans that have expired
-  const expiredBans = bans.filter(
-    (ban: Bans): ban is Bans =>
-      !!ban.expires_at && ban.expires_at.getTime() < currentTime,
+  // Only pick up bans that have expired and whose expiry has not yet been
+  // handled (permanent bans have expires_at NULL and are never selected).
+  const res = await pool.query<Bans>(
+    `SELECT * FROM "bans"
+     WHERE expires_at IS NOT NULL
+       AND expires_at < NOW()
+       AND expiry_handled = false`,
   )
 
   // unban user
-  for (const expiredBan of expiredBans) {
+  for (const expiredBan of res.rows) {
     await automaticUnban(expiredBan)
   }
 }

--- a/src/utils/calculateExpiryDate.ts
+++ b/src/utils/calculateExpiryDate.ts
@@ -1,31 +1,30 @@
 import { getUserStrikes } from './queryDB'
 
-// for calculating how long the expiry should be on a strike, based on a few crude methods
+// Calculate how long a newly-issued strike should last. Expiry scales
+// quadratically with the user's total *active* strike count, including the
+// strikes being issued right now, so issuing several at once (a major offense)
+// is punished much harder than a single strike.
+//
+//   T (active strikes incl. this issuance):  1    2    3    4
+//   expiry (days = 7 * T^2):                 7   28   63  112
 export async function calculateExpiryDate(
   user_id: string,
-): Promise<Date | null> {
+  amount: number,
+): Promise<Date> {
   const dayLength = 1000 * 60 * 60 * 24
-  const currentDate = new Date()
-  const res = await getUserStrikes(user_id)
-  let lengthOfBan: number = 14 // default strike expiry timer
+  const now = Date.now()
 
-  const strikes = res.map((strike) => {
-    const currentDate = new Date()
-    const expired: boolean = strike.expires_at >= currentDate
-    return { amount: strike.amount, expired: expired }
-  })
+  const strikes = await getUserStrikes(user_id)
 
-  const totalStrikes = strikes.reduce((sum, strike) => {
-    return sum + strike.amount
-  }, 0)
+  // Only non-expired strikes count toward the total. Expired strikes are kept
+  // as a permanent record but no longer influence escalation.
+  const activeTotalBefore = strikes
+    .filter((strike) => new Date(strike.expires_at).getTime() > now)
+    .reduce((sum, strike) => sum + strike.amount, 0)
 
-  const severeStrikes = strikes.filter((strike) => {
-    // checks if a user has ever had a more serious incident
-    return strike.amount >= 1
-  })
+  // Floor at 1 so a degenerate amount of 0 still produces a sane expiry.
+  const totalStrikes = Math.max(1, activeTotalBefore + amount)
+  const expiryDays = 7 * totalStrikes * totalStrikes
 
-  lengthOfBan += totalStrikes * 7
-  lengthOfBan += severeStrikes.length * 14
-
-  return new Date(currentDate.getTime() + dayLength * lengthOfBan)
+  return new Date(now + dayLength * expiryDays)
 }

--- a/src/utils/cronJobs.ts
+++ b/src/utils/cronJobs.ts
@@ -19,7 +19,6 @@ import {
   replenishReservePool,
   updateMatchCountChannel,
 } from './matchHelpers'
-import { pool } from '../db'
 import * as fs from 'fs'
 import * as path from 'path'
 import { glob } from 'glob'
@@ -279,24 +278,4 @@ export async function updateMatchCountCronJob() {
     },
     7 * 60 * 1000,
   ) // every 7 mins
-}
-
-// delete expired strikes every 2 hours
-export async function deleteExpiredStrikesCronJob() {
-  setInterval(
-    async () => {
-      try {
-        const res = await pool.query(
-          `DELETE FROM strikes WHERE expires_at < NOW() RETURNING id`,
-        )
-        const deletedCount = res.rowCount || 0
-        if (deletedCount > 0) {
-          console.log(`Deleted ${deletedCount} expired strike(s)`)
-        }
-      } catch (err) {
-        console.error('Error deleting expired strikes:', err)
-      }
-    },
-    2 * 60 * 60 * 1000,
-  ) // every 2 hours
 }

--- a/src/utils/queueHelpers.ts
+++ b/src/utils/queueHelpers.ts
@@ -232,6 +232,28 @@ export async function joinQueues(
   const guild = await getGuild()
   const member = await guild.members.fetch(userId)
 
+  // Ban check — enforced here (the single chokepoint for every join path).
+  // Blocks on the blacklist role OR an active DB ban, so a banned user is
+  // stopped even if they shed the role by leaving and rejoining the server
+  // (DB), and a manually role-blacklisted user is stopped too (role).
+  const hasBlacklistRole = member.roles.cache.has('1354296037094854788')
+  const banCheck = await pool.query(
+    `SELECT 1 FROM bans
+     WHERE user_id = $1
+       AND (expires_at IS NULL OR expires_at > NOW())
+     LIMIT 1`,
+    [userId],
+  )
+  const hasDbBan = !!banCheck.rowCount && banCheck.rowCount > 0
+  if (hasBlacklistRole || hasDbBan) {
+    await interaction
+      ?.editReply({
+        content: 'You are queue blacklisted, and cannot join the queue.',
+      })
+      .catch((e) => console.error(e))
+    return null
+  }
+
   // Ensure user exists
   await pool.query(
     'INSERT INTO users (user_id) VALUES ($1) ON CONFLICT DO NOTHING',


### PR DESCRIPTION
## Summary

Two related moderation fixes.

### 1. Bans survive leave/rejoin (`f2ef8a5`)
A banned user could leave and rejoin the server to shed the blacklist roles, escaping the visual marker and tournament blacklisting. Queue enforcement also lived only in the select-menu handler and led with the role check, so the `addUserToQueue` mod command bypassed it.

- `joinQueues` (the single chokepoint for every join path) now blocks on the blacklist role **OR** an active DB ban, keyed off `bans.user_id` rather than the role alone.
- `guildMemberAdd` re-applies both blacklist roles when a rejoining member still has an active ban in the DB.

### 2. Persist expired strikes/bans + harsher strike scaling (`3935e27`)
Expired strikes and bans were hard-deleted, wiping moderator history and silently resetting a user's record. Deletion was also the only thing that made "total strikes" mean "active strikes", so explicit `expires_at > NOW()` filters are added wherever a current total is needed.

- **Strikes:** dropped the deletion cron. Rows are kept; all current-total queries (escalation, expiry calc, website aggregates/filters/counts) now filter active.
- **Bans:** stop deleting on expiry. New `bans.expiry_handled` flag (migration `1780000000000`) lets `automaticUnban` run its one-time side effects (role removal, DM, log) exactly once while keeping the row. `createBan` resets the flag on re-ban.
- **Views:** `/list strikes` and `/ban list` show expired entries tagged `[EXPIRED]` vs `[ACTIVE]`, active-first, with active-only summary counts. Unban autocomplete only offers currently-banned users.
- **Scaling:** strike expiry now scales quadratically with active strike count incl. the amount being issued (`7*T^2` days: 1→7, 2→28, 3→63, 4→112), so multiple strikes at once are punished as a major offense.

## Testing
- `tsc` build passes.
- Full `docker compose up --build` stack verified locally against the dev bot: migration applied cleanly, all stages exited 0, bot logged in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)