### PR TITLE
Paginate long list command outputs with arrow buttons

### DIFF
--- a/src/commands/moderation/listQueueUsers.ts
+++ b/src/commands/moderation/listQueueUsers.ts
@@ -1,5 +1,6 @@
 import { ChatInputCommandInteraction, MessageFlags } from 'discord.js'
 import { getQueueIdFromName, getUsersInQueue } from 'utils/queryDB'
+import { sendPaginatedEmbed } from '../../utils/paginatedEmbed'
 
 export default {
   async execute(interaction: ChatInputCommandInteraction) {
@@ -15,23 +16,13 @@ export default {
       }
 
       const queueUsers = await getUsersInQueue(queueId)
-      const formattedQueueUsers = queueUsers
-        .map((userId: string) => {
-          return `<@${userId}>`
-        })
-        .join('\n')
 
-      if (queueUsers.length > 0) {
-        await interaction.reply({
-          content: `**Users in Queue for ${queueName}**\n${formattedQueueUsers}`,
-          flags: MessageFlags.Ephemeral,
-        })
-      } else {
-        await interaction.reply({
-          content: `No users are currently in the queue for **${queueName}**.`,
-          flags: MessageFlags.Ephemeral,
-        })
-      }
+      await sendPaginatedEmbed(interaction, {
+        title: `Users in Queue for ${queueName}`,
+        summary: `Total: ${queueUsers.length}`,
+        emptyState: `No users are currently in the queue for **${queueName}**.`,
+        entries: queueUsers.map((userId: string) => `<@${userId}>`),
+      })
     } catch (err: any) {
       console.error(err)
       const errorMsg = err.detail || err.message || 'Unknown'

--- a/src/commands/moderation/playerModeration/listBannedUsers.ts
+++ b/src/commands/moderation/playerModeration/listBannedUsers.ts
@@ -1,12 +1,9 @@
 import { ChatInputCommandInteraction, MessageFlags } from 'discord.js'
 import { pool } from '../../../db'
 import { Bans } from 'psqlDB'
-import {
-  createModerationListEmbed,
-  formatBanLogEntry,
-  isExpired,
-} from './moderationLogUtils'
+import { formatBanLogEntry, isExpired } from './moderationLogUtils'
 import { resolveModerationTarget } from '../../../command-handlers/moderation/resolveModerationTarget'
+import { sendPaginatedEmbed } from '../../../utils/paginatedEmbed'
 
 export default {
   async execute(interaction: ChatInputCommandInteraction) {
@@ -46,7 +43,7 @@ export default {
       )
       const targetLookup = new Map<string, string>(targetEntries)
 
-      const embed = createModerationListEmbed({
+      await sendPaginatedEmbed(interaction, {
         title: 'Ban Log',
         summary: `Active bans: ${activeBanCount}${expiredBanCount > 0 ? ` · Expired: ${expiredBanCount}` : ''}`,
         emptyState: 'No bans on record.',
@@ -57,8 +54,6 @@ export default {
           ),
         ),
       })
-
-      await interaction.editReply({ embeds: [embed] })
     } catch (err: any) {
       console.error(err)
     }

--- a/src/commands/moderation/playerModeration/listStrikes.ts
+++ b/src/commands/moderation/playerModeration/listStrikes.ts
@@ -1,11 +1,8 @@
 import { ChatInputCommandInteraction, MessageFlags } from 'discord.js'
 import { strikeUtils } from '../../../utils/queryDB'
 import { getGuild } from '../../../client'
-import {
-  createModerationListEmbed,
-  formatStrikeLogEntry,
-  isExpired,
-} from './moderationLogUtils'
+import { formatStrikeLogEntry, isExpired } from './moderationLogUtils'
+import { sendPaginatedEmbed } from '../../../utils/paginatedEmbed'
 
 export default {
   async execute(interaction: ChatInputCommandInteraction) {
@@ -48,7 +45,7 @@ export default {
         isExpired(strike.expires_at),
       ).length
 
-      const embed = createModerationListEmbed({
+      await sendPaginatedEmbed(interaction, {
         title: `${member.displayName} Strike Log`,
         summary: `Active strikes: ${activeStrikes} · Entries: ${sortedStrikes.length}${expiredCount > 0 ? ` (${expiredCount} expired)` : ''}`,
         emptyState: 'No strikes found for this user.',
@@ -59,8 +56,6 @@ export default {
           ),
         ),
       })
-
-      await interaction.editReply({ embeds: [embed] })
     } catch (err: any) {
       console.error(err)
     }

--- a/src/commands/moderation/playerModeration/moderationLogUtils.ts
+++ b/src/commands/moderation/playerModeration/moderationLogUtils.ts
@@ -1,8 +1,5 @@
-import { EmbedBuilder, Guild } from 'discord.js'
+import { Guild } from 'discord.js'
 import type { Bans, Strikes } from 'psqlDB'
-
-const MODERATION_LIST_COLOR = 0x5865f2
-const MAX_FIELD_VALUE_LENGTH = 1024
 
 function normalizeText(
   value: string | number | null | undefined,
@@ -34,74 +31,6 @@ export function isExpired(expiresAt: Date | null | undefined): boolean {
   return new Date(expiresAt).getTime() < Date.now()
 }
 
-function chunkEntries(entries: string[]) {
-  const chunks: { start: number; end: number; value: string }[] = []
-  let currentValue = ''
-  let currentStart = 0
-
-  entries.forEach((entry, index) => {
-    const nextValue =
-      currentValue.length === 0 ? entry : `${currentValue}\n\n${entry}`
-
-    if (nextValue.length > MAX_FIELD_VALUE_LENGTH && currentValue.length > 0) {
-      chunks.push({
-        start: currentStart + 1,
-        end: index,
-        value: currentValue,
-      })
-      currentValue = entry
-      currentStart = index
-      return
-    }
-
-    currentValue = nextValue
-  })
-
-  if (currentValue.length > 0) {
-    chunks.push({
-      start: currentStart + 1,
-      end: entries.length,
-      value: currentValue,
-    })
-  }
-
-  return chunks
-}
-
-export function createModerationListEmbed({
-  title,
-  summary,
-  emptyState,
-  entries,
-}: {
-  title: string
-  summary: string
-  emptyState: string
-  entries: string[]
-}) {
-  const embed = new EmbedBuilder()
-    .setColor(MODERATION_LIST_COLOR)
-    .setTitle(title)
-    .setDescription(summary)
-    .setTimestamp()
-
-  if (entries.length === 0) {
-    embed.addFields({ name: 'Entries', value: emptyState, inline: false })
-    return embed
-  }
-
-  const chunks = chunkEntries(entries)
-  for (const chunk of chunks) {
-    embed.addFields({
-      name:
-        chunks.length === 1 ? 'Entries' : `Entries ${chunk.start}-${chunk.end}`,
-      value: chunk.value,
-      inline: false,
-    })
-  }
-
-  return embed
-}
 
 export function formatBanLogEntry(ban: Bans, targetLabel: string) {
   const relatedStrikes =

--- a/src/commands/party/listAllOpenParties.ts
+++ b/src/commands/party/listAllOpenParties.ts
@@ -1,5 +1,6 @@
 import { ChatInputCommandInteraction, MessageFlags } from 'discord.js'
 import { partyUtils } from '../../utils/queryDB'
+import { sendPaginatedEmbed } from '../../utils/paginatedEmbed'
 
 export default {
   async execute(interaction: ChatInputCommandInteraction) {
@@ -7,18 +8,14 @@ export default {
 
     try {
       const parties = await partyUtils.listAllParties()
-      if (!parties || parties.length === 0) {
-        await interaction.editReply({
-          content: `There are currently no parties.`,
-        })
-        return
-      }
 
-      const partyList = parties.map((party) => {
-        return `- ${party.name} (ID: ${party.id})`
-      })
-      await interaction.editReply({
-        content: `All Parties: \n${partyList.join('\n')}`,
+      await sendPaginatedEmbed(interaction, {
+        title: 'All Parties',
+        summary: `Total: ${parties?.length ?? 0}`,
+        emptyState: 'There are currently no parties.',
+        entries: (parties ?? []).map(
+          (party) => `- ${party.name} (ID: ${party.id})`,
+        ),
       })
     } catch (err: any) {
       console.error(err)

--- a/src/utils/paginatedEmbed.ts
+++ b/src/utils/paginatedEmbed.ts
@@ -1,0 +1,175 @@
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  ChatInputCommandInteraction,
+  ComponentType,
+  EmbedBuilder,
+  MessageFlags,
+} from 'discord.js'
+
+const DEFAULT_COLOR = 0x5865f2
+// Discord caps an embed description at 4096 chars; stay well under it.
+const MAX_PAGE_LENGTH = 3800
+// Soft cap so pages stay readable even when entries are short.
+const MAX_ENTRIES_PER_PAGE = 12
+const ENTRY_SEPARATOR = '\n\n'
+const COLLECTOR_TIMEOUT_MS = 5 * 60 * 1000
+
+const PREV_ID = 'paginate_prev'
+const NEXT_ID = 'paginate_next'
+
+type PaginateOptions = {
+  maxPageLength?: number
+  maxEntriesPerPage?: number
+}
+
+// Greedily pack entries into pages, splitting when the next entry would push a
+// page past the length budget or the per-page entry cap (dynamic content-length
+// detection). An entry larger than the budget still gets its own page.
+export function paginateEntries(
+  entries: string[],
+  {
+    maxPageLength = MAX_PAGE_LENGTH,
+    maxEntriesPerPage = MAX_ENTRIES_PER_PAGE,
+  }: PaginateOptions = {},
+): string[][] {
+  const pages: string[][] = []
+  let current: string[] = []
+  let currentLength = 0
+
+  for (const entry of entries) {
+    const separatorLength = current.length > 0 ? ENTRY_SEPARATOR.length : 0
+    const wouldOverflow =
+      currentLength + separatorLength + entry.length > maxPageLength
+    const wouldExceedCount = current.length >= maxEntriesPerPage
+
+    if (current.length > 0 && (wouldOverflow || wouldExceedCount)) {
+      pages.push(current)
+      current = []
+      currentLength = 0
+    }
+
+    currentLength +=
+      (current.length > 0 ? ENTRY_SEPARATOR.length : 0) + entry.length
+    current.push(entry)
+  }
+
+  if (current.length > 0) pages.push(current)
+  return pages
+}
+
+function buildButtons(pageIndex: number, totalPages: number, disabled = false) {
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(PREV_ID)
+      .setLabel('◀')
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(disabled || pageIndex === 0),
+    new ButtonBuilder()
+      .setCustomId(NEXT_ID)
+      .setLabel('▶')
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(disabled || pageIndex === totalPages - 1),
+  )
+}
+
+type SendPaginatedEmbedOptions = {
+  title: string
+  entries: string[]
+  /** Summary shown in the footer (e.g. counts). "Page X/Y" is appended automatically. */
+  summary?: string
+  emptyState: string
+  color?: number
+  ephemeral?: boolean
+}
+
+// Render a list as a paginated embed. With a single page no buttons are shown;
+// with multiple pages, ◀ / ▶ buttons let the invoker page through. The collector
+// only responds to the user who ran the command and disables itself on timeout.
+export async function sendPaginatedEmbed(
+  interaction: ChatInputCommandInteraction,
+  {
+    title,
+    entries,
+    summary,
+    emptyState,
+    color = DEFAULT_COLOR,
+    ephemeral = true,
+  }: SendPaginatedEmbedOptions,
+) {
+  if (!interaction.deferred && !interaction.replied) {
+    await interaction.deferReply(
+      ephemeral ? { flags: MessageFlags.Ephemeral } : {},
+    )
+  }
+
+  if (entries.length === 0) {
+    const embed = new EmbedBuilder()
+      .setColor(color)
+      .setTitle(title)
+      .setDescription(emptyState)
+      .setTimestamp()
+    await interaction.editReply({ embeds: [embed], components: [] })
+    return
+  }
+
+  const pages = paginateEntries(entries)
+
+  const buildEmbed = (pageIndex: number) => {
+    const footerParts = [
+      summary,
+      pages.length > 1 ? `Page ${pageIndex + 1}/${pages.length}` : undefined,
+    ].filter((part): part is string => Boolean(part))
+
+    const embed = new EmbedBuilder()
+      .setColor(color)
+      .setTitle(title)
+      .setDescription(pages[pageIndex].join(ENTRY_SEPARATOR))
+      .setTimestamp()
+
+    if (footerParts.length > 0) {
+      embed.setFooter({ text: footerParts.join(' · ') })
+    }
+    return embed
+  }
+
+  if (pages.length === 1) {
+    await interaction.editReply({ embeds: [buildEmbed(0)], components: [] })
+    return
+  }
+
+  let pageIndex = 0
+  const message = await interaction.editReply({
+    embeds: [buildEmbed(pageIndex)],
+    components: [buildButtons(pageIndex, pages.length)],
+  })
+
+  const collector = message.createMessageComponentCollector({
+    componentType: ComponentType.Button,
+    filter: (i) => i.user.id === interaction.user.id,
+    time: COLLECTOR_TIMEOUT_MS,
+  })
+
+  collector.on('collect', async (buttonInteraction) => {
+    if (buttonInteraction.customId === PREV_ID) {
+      pageIndex = Math.max(0, pageIndex - 1)
+    } else if (buttonInteraction.customId === NEXT_ID) {
+      pageIndex = Math.min(pages.length - 1, pageIndex + 1)
+    }
+
+    await buttonInteraction.update({
+      embeds: [buildEmbed(pageIndex)],
+      components: [buildButtons(pageIndex, pages.length)],
+    })
+  })
+
+  collector.on('end', async () => {
+    await interaction
+      .editReply({
+        embeds: [buildEmbed(pageIndex)],
+        components: [buildButtons(pageIndex, pages.length, true)],
+      })
+      .catch(() => {})
+  })
+}


### PR DESCRIPTION
## Summary
Long list commands silently truncated their output — most visibly `/ban list`, which only showed the first ~7-10 rows because the embed hit Discord's ~6000-char total limit. Content-string lists (`/list queue-users`, `/list parties`) could likewise blow past the 2000-char message cap.

## Changes
- New reusable `sendPaginatedEmbed` helper (`src/utils/paginatedEmbed.ts`):
  - **Dynamic content-length detection** — greedily packs entries into pages, splitting before a page exceeds the 4096-char embed description limit (with a soft per-page entry cap).
  - **◀ / ▶ buttons** (simple unicode arrows) appear only when there's more than one page; a single page renders with no buttons.
  - Collector only responds to the command invoker, disables Prev/Next at the ends, and greys the buttons out on timeout (5 min).
- Applied to the lists that realistically overflow: `/ban list`, `/list strikes`, `/list queue-users`, `/list parties`.
- `/list queue-users` mentions now live in an embed description, so listing a queue **no longer pings everyone in it**.
- Removed the now-dead `createModerationListEmbed` / `chunkEntries` field-chunking helpers.

Bounded lists (`/list queue-roles`, `/list party-members`, bounties, queue settings) were left as-is — they can't realistically overflow.

## Testing
- `tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)